### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/himiyaza/7ecfa090-f719-4e00-a538-61275ee5cdf0/790ad45f-aec3-4882-bd14-fe697611092e/_apis/work/boardbadge/72e5675f-b444-48d7-be25-28afb75c369f)](https://dev.azure.com/himiyaza/7ecfa090-f719-4e00-a538-61275ee5cdf0/_boards/board/t/790ad45f-aec3-4882-bd14-fe697611092e/Microsoft.FeatureCategory)
 # This project is retired, archived, and no longer supported. You are welcome to continue to use and fork the repository.
 
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#4129](https://dev.azure.com/himiyaza/7ecfa090-f719-4e00-a538-61275ee5cdf0/_workitems/edit/4129). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.